### PR TITLE
Support deploying multiple SSL checks

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   statuscake_api_token                     = var.statuscake_api_token
   statuscake_check_interval                = var.statuscake_check_interval
-  statuscake_monitored_resource_address    = var.statuscake_monitored_resource_address
+  statuscake_monitored_resource_addresses  = var.statuscake_monitored_resource_addresses
   statuscake_alert_at                      = var.statuscake_alert_at
   statuscake_notify_on_reminder            = var.statuscake_notify_on_reminder
   statuscake_notify_on_expiry              = var.statuscake_notify_on_expiry

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -1,4 +1,6 @@
 resource "statuscake_ssl_check" "main" {
+  for_each = local.statuscake_monitored_resource_addresses
+
   check_interval = local.statuscake_check_interval
   contact_groups = [statuscake_contact_group.monitoring_team[0].id]
 
@@ -12,7 +14,7 @@ resource "statuscake_ssl_check" "main" {
   }
 
   monitored_resource {
-    address = local.statuscake_monitored_resource_address
+    address = each.value
   }
 }
 

--- a/tfvars.example
+++ b/tfvars.example
@@ -1,8 +1,8 @@
 statuscake_api_token                     = "000-11-222-3333-44-555"
 statuscake_check_interval                = 86400 # check every 24 hours
-statuscake_monitored_resource_address    = "https://www.my-website-to-check.education.gov.uk"
+statuscake_monitored_resource_addresses  = ["https://www.my-website-to-check.education.gov.uk"]
 statuscake_alert_at                      = [ # days to alert on
-  60, 30, 14
+  30, 14, 7
 ]
 statuscake_notify_on_reminder            = true
 statuscake_notify_on_expiry              = true

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,10 @@ variable "statuscake_api_token" {
   sensitive   = true
 }
 
-variable "statuscake_monitored_resource_address" {
-  description = "The URL to perform TLS checks on"
-  type        = string
+variable "statuscake_monitored_resource_addresses" {
+  description = "The URLs to perform TLS checks on"
+  type        = list(string)
+  default     = []
 }
 
 variable "statuscake_alert_at" {


### PR DESCRIPTION
* This is useful if you want to associate multiple SSL Checks with a single contact group
* Updated Readme to show how one can use the module to deploy 1 monitor or many